### PR TITLE
Reflection testcases

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/commons/util/GenericClassHierarchiesReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/GenericClassHierarchiesReflectionUtilsTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.junit.platform.commons.util.ReflectionUtils.findMethod;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class GenericClassHierarchiesReflectionUtilsTests {
+	@Test
+	@Disabled("Describes a new case that does not yet yield the expected result.")
+	void findsMethodsIndependentlyFromOrderOfImplementationsOfInterfaces() {
+
+		class AB implements InterfaceDouble, InterfaceGenericNumber {
+		}
+
+		class BA implements InterfaceGenericNumber, InterfaceDouble {
+		}
+
+		var methodAB = findMethod(AB.class, "foo", Double.class).orElseThrow();
+		var methodBA = findMethod(BA.class, "foo", Double.class).orElseThrow();
+
+		Assertions.assertEquals(methodAB, methodBA);
+	}
+
+	@Test
+	void findMoreSpecificMethodFromAbstractImplementationOverDefaultInterfaceMethod() {
+		class A implements InterfaceGenericNumber<Long> {
+			@Override
+			public void foo(Long parameter) {
+
+			}
+		}
+
+		Method foo = findMethod(A.class, "foo", Long.class).orElseThrow();
+
+		Assertions.assertEquals(A.class, foo.getDeclaringClass());
+	}
+
+	@Test
+	@Disabled("Describes a new case that does not yet yield the expected result.")
+	void findMoreSpecificMethodFromOverriddenImplementationOfGenericInterfaceMethod() {
+		class A implements InterfaceGenericNumber<Number> {
+			@Override
+			public void foo(Number parameter) {
+			}
+		}
+
+		Method foo = findMethod(A.class, "foo", Long.class).orElseThrow();
+
+		Assertions.assertEquals(A.class, foo.getDeclaringClass());
+	}
+
+	@Test
+	@Disabled("Describes a new case that does not yet yield the expected result.")
+	void findMoreSpecificMethodFromImplementationOverDefaultInterfaceMethodAndGenericClassExtension() {
+
+		class AParent {
+			public void foo(Number parameter) {
+			}
+		}
+
+		class A extends AParent implements InterfaceGenericNumber<Number> {
+			@Override
+			public void foo(Number parameter) {
+
+			}
+		}
+
+		Method foo = findMethod(A.class, "foo", Long.class).orElseThrow();
+
+		Assertions.assertEquals(A.class, foo.getDeclaringClass());
+	}
+
+	@Test
+	@Disabled("Expected behaviour is not clear yet.")
+	void unclearPrecedenceOfImplementationsInParentClassAndInterfaceDefault() {
+
+		class AParent {
+			public void foo(Number parameter) {
+			}
+		}
+
+		class A extends AParent implements InterfaceGenericNumber<Number> {
+		}
+
+		Method foo = findMethod(A.class, "foo", Long.class).orElseThrow();
+
+		// ????????
+		Assertions.assertEquals(A.class, foo.getDeclaringClass());
+		Assertions.assertEquals(AParent.class, foo.getDeclaringClass());
+		Assertions.assertEquals(InterfaceGenericNumber.class, foo.getDeclaringClass());
+	}
+
+	interface InterfaceDouble {
+		default void foo(Double parameter) {
+		}
+	}
+
+	interface InterfaceGenericNumber<T extends Number> {
+		default void foo(T parameter) {
+		}
+	}
+}


### PR DESCRIPTION
Add tests covering method selection edge cases.
These tests show that generic interfaces with a
default implementation can lead to unwanted
behaviour when selecting a method with a
parameter type that extends the used generic
type.

Issue: #981

## Overview

Please describe your changes here and list any open questions you might have.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
